### PR TITLE
Add monorepo GitHub Actions CI with separate backend and frontend jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,45 +1,59 @@
-name: Spring Boot Maven CI
+name: Monorepo CI
 
 on:
   push:
     branches:
       - master
+      - work
   pull_request:
     branches:
       - master
+      - work
+  workflow_dispatch:
 
 jobs:
-  build:
+  backend:
+    name: Backend Test (Spring Boot)
     runs-on: ubuntu-latest
-
+    defaults:
+      run:
+        working-directory: coder-practice-backend
     steps:
-      # 1️⃣ 检出代码
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # 2️⃣ 设置 JDK 21
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: '21'
+          cache: maven
 
-      # 3️⃣ 缓存 Maven 本地依赖，加速构建
-      - name: Cache Maven packages
-        uses: actions/cache@v3
+      - name: Run backend tests
+        run: mvn -B test
+
+  frontend:
+    name: Frontend Lint & Build (Vue)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: coder-practice-frontend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: coder-practice-frontend/package-lock.json
 
-   # 4️⃣ 编译项目（跳过测试）
-      - name: Build with Maven
-        run: mvn clean install -DskipTests
-        working-directory: backend
+      - name: Install dependencies
+        run: npm ci
 
+      - name: Lint frontend
+        run: npm run lint
 
-      # 5️⃣ 运行单元测试
-      - name: Run Tests
-        run: mvn test
-        working-directory: backend
+      - name: Build frontend
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -109,3 +109,25 @@ npm run dev
 
 - 后端：分层架构（Controller → Service → Mapper），统一异常处理，MyBatis Plus
 - 前端：Vue 3 + Pinia，组件单一职责，ESLint + Prettier 格式化
+
+## 🔁 CI（持续集成）说明
+
+本项目使用 GitHub Actions 做自动化检查，工作流文件位于：`\.github/workflows/ci.yml`。
+
+触发时机：
+
+- push 到 `master` 或 `work` 分支
+- 提交面向 `master` 或 `work` 的 Pull Request
+- 在 GitHub Actions 页面手动触发（workflow_dispatch）
+
+执行内容：
+
+- 后端：Java 21 环境下执行 `mvn -B test`
+- 前端：Node 20 环境下执行 `npm ci`、`npm run lint`、`npm run build`
+
+CI 的价值：
+
+- 提交后自动验证，降低“本地可跑、线上失败”的风险
+- PR 合并前提前发现问题，保障主分支稳定
+- 让团队协作更标准化，减少重复手工检查
+- CI 触发测试：仅修改文档并 push 到 `work` 分支，也会触发该工作流（当前未配置 paths 过滤）


### PR DESCRIPTION
### Motivation

- Consolidate CI for the monorepo to run backend and frontend checks independently.
- Add support for the `work` branch and manual triggering via `workflow_dispatch`, and modernize action versions.
- Surface CI behavior in the project documentation by adding a CI section to `README.md`.

### Description

- Rename the workflow to `Monorepo CI` and add triggers for pushes and PRs to `master` and `work`, plus `workflow_dispatch` for manual runs.
- Split the single job into `backend` and `frontend` jobs and set `defaults.working-directory` to `coder-practice-backend` and `coder-practice-frontend` respectively.
- Upgrade actions to `actions/checkout@v4`, `actions/setup-java@v4` with Maven caching, and add `actions/setup-node@v4` with npm caching and `node-version: '20'`.
- Configure the backend to run `mvn -B test` and the frontend to run `npm ci`, `npm run lint`, and `npm run build`, and add a `CI` explanation to `README.md`.

### Testing

- No automated CI runs were executed as part of this configuration change.
- The added workflow is configured to run backend tests via `mvn -B test` and frontend checks via `npm ci`, `npm run lint`, and `npm run build` when triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a917de1ddc832b988e45daf0010b80)